### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/551/591/102551591.geojson
+++ b/data/102/551/591/102551591.geojson
@@ -13,11 +13,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:ara_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u0641\u0627\u063a\u0627\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u06a4\u0627\u062c\u0627\u0631 \u0627\u064a\u0631\u067e\u0648\u0631\u062a"
+    ],
     "name:cat_x_preferred":[
         "Aeroport de V\u00e1gar"
     ],
     "name:ces_x_preferred":[
         "Leti\u0161t\u011b V\u00e1gar"
+    ],
+    "name:cym_x_preferred":[
+        "Maes Awyr V\u00e1gar"
     ],
     "name:dan_x_preferred":[
         "V\u00e1gar Lufthavn"
@@ -67,6 +76,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubcf4\uac00\ub974 \uacf5\ud56d"
+    ],
+    "name:lav_x_preferred":[
+        "Voaras lidosta"
     ],
     "name:lit_x_preferred":[
         "Vagaro oro uostas"
@@ -145,7 +157,7 @@
         }
     ],
     "wof:id":102551591,
-    "wof:lastmodified":1631744577,
+    "wof:lastmodified":1690893379,
     "wof:name":"Vagar Airport",
     "wof:parent_id":85671213,
     "wof:placetype":"campus",

--- a/data/112/576/720/9/1125767209.geojson
+++ b/data/112/576/720/9/1125767209.geojson
@@ -25,6 +25,9 @@
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u041a\u0443\u043d\u043e\u0439"
     ],
+    "name:cat_x_preferred":[
+        "Kunoy"
+    ],
     "name:dan_x_preferred":[
         "Kunoy bygd"
     ],
@@ -94,6 +97,9 @@
     "name:zho_x_preferred":[
         "\u6606\u5c9b"
     ],
+    "name:zho_x_variant":[
+        "\u6606\u8bfa\u4f0a"
+    ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
     "qs_pg:gn_fcode":"PPL",
@@ -148,7 +154,7 @@
         }
     ],
     "wof:id":1125767209,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893393,
     "wof:name":"Kunoy",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/577/464/9/1125774649.geojson
+++ b/data/112/577/464/9/1125774649.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Sk\u00e6lingur"
+    ],
+    "name:cat_x_preferred":[
+        "Sk\u00e6lingur"
+    ],
     "name:dan_x_preferred":[
         "Sk\u00e6lingur"
     ],
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":1125774649,
-    "wof:lastmodified":1566596213,
+    "wof:lastmodified":1690893395,
     "wof:name":"Sk\u00e6lingur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/578/625/7/1125786257.geojson
+++ b/data/112/578/625/7/1125786257.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Velbasta\u00f0ur"
+    ],
+    "name:cat_x_preferred":[
+        "Velbasta\u00f0ur"
+    ],
     "name:dan_x_preferred":[
         "Velbasta\u00f0ur"
     ],
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":1125786257,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893393,
     "wof:name":"Velbasta\u00ffur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/579/807/3/1125798073.geojson
+++ b/data/112/579/807/3/1125798073.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Dalur"
+    ],
     "name:dan_x_preferred":[
         "Dalur"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:fra_x_preferred":[
         "Dalur"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d3\u05d0\u05dc\u05d5\u05e8"
     ],
     "name:hun_x_preferred":[
         "Dalur"
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":1125798073,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893394,
     "wof:name":"Dalur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/579/813/9/1125798139.geojson
+++ b/data/112/579/813/9/1125798139.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sy\u00f0radalur"
+    ],
     "name:dan_x_preferred":[
         "Sy\u00f0radalur"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:fra_x_preferred":[
         "Sy\u00f0radalur"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05e8\u05d0\u05d3\u05d0\u05dc\u05d5\u05e8"
     ],
     "name:hun_x_preferred":[
         "Sy\u00f0radalur"
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":1125798139,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893394,
     "wof:name":"Sy\u00ffradalur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/580/517/1/1125805171.geojson
+++ b/data/112/580/517/1/1125805171.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Gj\u00f3gv"
+    ],
     "name:ces_x_preferred":[
         "Gj\u00f3gv"
     ],
@@ -44,6 +47,9 @@
         "Gj\u00f3gv"
     ],
     "name:hun_x_preferred":[
+        "Gj\u00f3gv"
+    ],
+    "name:ita_x_preferred":[
         "Gj\u00f3gv"
     ],
     "name:kal_x_preferred":[
@@ -78,6 +84,9 @@
     ],
     "name:und_x_variant":[
         "Vi\u00f0 Gj\u00f3gv"
+    ],
+    "name:zho_x_preferred":[
+        "\u6770\u683c\u592b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -133,7 +142,7 @@
         }
     ],
     "wof:id":1125805171,
-    "wof:lastmodified":1566596207,
+    "wof:lastmodified":1690893385,
     "wof:name":"Gj\u00f3gv",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/580/517/7/1125805177.geojson
+++ b/data/112/580/517/7/1125805177.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Kirkjub\u00f8ur"
+    ],
     "name:cat_x_preferred":[
         "Kirkjub\u00f8ur"
     ],
@@ -52,6 +55,9 @@
     "name:ita_x_preferred":[
         "Kirkjub\u00f8ur"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ad\u30eb\u30af\u30b7\u30e5\u30dc\u30a2"
+    ],
     "name:nld_x_preferred":[
         "Kirkjub\u00f8ur"
     ],
@@ -73,11 +79,17 @@
     "name:rus_x_preferred":[
         "\u0427\u0438\u0440\u0447\u044e\u0431\u0451\u0432\u0443\u0440"
     ],
+    "name:rus_x_variant":[
+        "\u0427\u0438\u0440\u0447\u0443\u0431\u0451\u0432\u0443\u0440"
+    ],
     "name:spa_x_preferred":[
         "Kirkjub\u00f8ur"
     ],
     "name:swe_x_preferred":[
         "Kirkjub\u00f8ur"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0427\u0438\u0440\u0447\u0443\u0431\u0435\u0432\u0443\u0440"
     ],
     "name:und_x_variant":[
         "Kirkeb\u00f6"
@@ -138,7 +150,7 @@
         }
     ],
     "wof:id":1125805177,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893385,
     "wof:name":"Kirkjub\u00f8ur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/580/562/3/1125805623.geojson
+++ b/data/112/580/562/3/1125805623.geojson
@@ -55,14 +55,23 @@
     "name:nob_x_preferred":[
         "Hattarv\u00edk"
     ],
+    "name:pol_x_preferred":[
+        "Hattarv\u00edk"
+    ],
     "name:ron_x_preferred":[
         "Hattarv\u00edk"
     ],
     "name:swe_x_preferred":[
         "Hattarv\u00edk"
     ],
+    "name:tur_x_preferred":[
+        "Hattarvik"
+    ],
     "name:und_x_variant":[
         "Hattervig"
+    ],
+    "name:zho_x_preferred":[
+        "\u54c8\u5854\u5c14\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -111,7 +120,7 @@
         }
     ],
     "wof:id":1125805623,
-    "wof:lastmodified":1566596207,
+    "wof:lastmodified":1690893385,
     "wof:name":"Hattarv\u00edk",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/580/566/3/1125805663.geojson
+++ b/data/112/580/566/3/1125805663.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Tj\u00f8rnuv\u00edk"
+    ],
+    "name:ces_x_preferred":[
+        "Tj\u00f8rnuv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Tj\u00f8rnuv\u00edk"
     ],
@@ -45,6 +51,12 @@
     ],
     "name:isl_x_preferred":[
         "Tj\u00f8rnuv\u00edk"
+    ],
+    "name:ita_x_preferred":[
+        "Tj\u00f8rnuv\u00edk"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30e3\u30a2\u30cc\u30f4\u30a3\u30af"
     ],
     "name:lit_x_preferred":[
         "Tjornuvikas"
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":1125805663,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893385,
     "wof:name":"Tj\u00f8rnuv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/580/567/5/1125805675.geojson
+++ b/data/112/580/567/5/1125805675.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Tr\u00f8llanes"
+    ],
     "name:dan_x_preferred":[
         "Tr\u00f8llanes"
     ],
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":1125805675,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893384,
     "wof:name":"Tr\u00f8llanes",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/581/309/5/1125813095.geojson
+++ b/data/112/581/309/5/1125813095.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Depil"
+    ],
     "name:dan_x_preferred":[
         "Depil"
     ],
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":1125813095,
-    "wof:lastmodified":1566596205,
+    "wof:lastmodified":1690893382,
     "wof:name":"Depil",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/582/402/1/1125824021.geojson
+++ b/data/112/582/402/1/1125824021.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sk\u00e1labotnur"
+    ],
     "name:dan_x_preferred":[
         "Sk\u00e1labotnur"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:nob_x_preferred":[
         "Sk\u00e1labotnur"
+    ],
+    "name:nob_x_variant":[
+        "\u00cd Sk\u00e1lafir\u00f0i"
     ],
     "name:ron_x_preferred":[
         "Sk\u00e1labotnur"
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":1125824021,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893393,
     "wof:name":"Sk\u00e1lafj\u00f8r\u00f0ur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/583/559/9/1125835599.geojson
+++ b/data/112/583/559/9/1125835599.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "H\u00fasav\u00edk"
+    ],
     "name:dan_x_preferred":[
         "H\u00fasav\u00edk"
     ],
@@ -63,6 +66,9 @@
     ],
     "name:und_x_variant":[
         "Husevig"
+    ],
+    "name:zho_x_preferred":[
+        "\u80e1\u8428\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":1125835599,
-    "wof:lastmodified":1566596213,
+    "wof:lastmodified":1690893396,
     "wof:name":"H\u00fasav\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/326/9/1125843269.geojson
+++ b/data/112/584/326/9/1125843269.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Kollafj\u00f8r\u00f0ur"
+    ],
+    "name:cat_x_preferred":[
+        "Kollafj\u00f8r\u00f0ur"
+    ],
     "name:dan_x_preferred":[
         "Kollafj\u00f8r\u00f0ur"
     ],
@@ -55,6 +61,9 @@
     "name:nld_x_preferred":[
         "Kollafj\u00f8r\u00f0ur"
     ],
+    "name:nno_x_preferred":[
+        "Kollafj\u00f8r\u00f0ur"
+    ],
     "name:nob_x_preferred":[
         "Kollafj\u00f8r\u00f0ur"
     ],
@@ -69,6 +78,9 @@
     ],
     "name:ron_x_preferred":[
         "Kollafj\u00f8r\u00f0ur"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u0434\u043b\u0430\u0444\u044c\u043e\u0440\u0434\u0443\u0440"
     ],
     "name:spa_x_preferred":[
         "Kollafj\u00f8r\u00f0ur"
@@ -119,7 +131,7 @@
         }
     ],
     "wof:id":1125843269,
-    "wof:lastmodified":1566596213,
+    "wof:lastmodified":1690893395,
     "wof:name":"Kollafj\u00f8r\u00f0ur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/327/5/1125843275.geojson
+++ b/data/112/584/327/5/1125843275.geojson
@@ -22,8 +22,17 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Hoyv\u00edk"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u043e\u0439\u0432\u0456\u043a"
+    ],
+    "name:bel_x_variant":[
+        "\u0425\u043e\u0439\u0432\u0456\u043a"
+    ],
+    "name:cat_x_preferred":[
+        "Hoyv\u00edk"
     ],
     "name:ces_x_preferred":[
         "Hoyv\u00edk"
@@ -52,6 +61,9 @@
     "name:fra_x_preferred":[
         "Hoyv\u00edk"
     ],
+    "name:frr_x_preferred":[
+        "Hoyv\u00edk"
+    ],
     "name:glv_x_preferred":[
         "Hoyv\u00edk"
     ],
@@ -59,6 +71,9 @@
         "Hoyv\u00edk"
     ],
     "name:isl_x_preferred":[
+        "Hoyv\u00edk"
+    ],
+    "name:ita_x_preferred":[
         "Hoyv\u00edk"
     ],
     "name:kal_x_preferred":[
@@ -155,7 +170,7 @@
         }
     ],
     "wof:id":1125843275,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893395,
     "wof:name":"Hoyv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/328/3/1125843283.geojson
+++ b/data/112/584/328/3/1125843283.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0647\u0648\u0633\u0627\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u0647\u0648\u0633\u0627\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "H\u00fasar"
+    ],
     "name:ces_x_preferred":[
         "H\u00fasar"
     ],
@@ -82,6 +91,9 @@
     "name:und_x_variant":[
         "Husum"
     ],
+    "name:zho_x_preferred":[
+        "\u80e1\u8428\u5c14"
+    ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
     "qs_pg:gn_fcode":"PPL",
@@ -122,7 +134,7 @@
         }
     ],
     "wof:id":1125843283,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893395,
     "wof:name":"H\u00fasar",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/409/3/1125844093.geojson
+++ b/data/112/584/409/3/1125844093.geojson
@@ -22,11 +22,23 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0645\u0628\u0627"
+    ],
+    "name:cat_x_preferred":[
+        "Lamba"
+    ],
     "name:dan_x_preferred":[
         "Lambi"
     ],
+    "name:dan_x_variant":[
+        "Lamba"
+    ],
     "name:deu_x_preferred":[
         "Lambi"
+    ],
+    "name:deu_x_variant":[
+        "Lamba"
     ],
     "name:eng_x_preferred":[
         "Lamba"
@@ -45,6 +57,9 @@
     ],
     "name:nob_x_preferred":[
         "Lambi"
+    ],
+    "name:nob_x_variant":[
+        "Lamba"
     ],
     "name:pol_x_preferred":[
         "Lambi"
@@ -120,7 +135,7 @@
         }
     ],
     "wof:id":1125844093,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893394,
     "wof:name":"Lambi",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/409/9/1125844099.geojson
+++ b/data/112/584/409/9/1125844099.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "\u00d8r\u00f0av\u00edk"
+    ],
     "name:dan_x_preferred":[
         "\u00d8rav\u00edk"
     ],
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":1125844099,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893394,
     "wof:name":"\u00d8rav\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/584/947/3/1125849473.geojson
+++ b/data/112/584/947/3/1125849473.geojson
@@ -28,6 +28,12 @@
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0425\u0435\u0441\u0442\u0443\u0440"
     ],
+    "name:cat_x_preferred":[
+        "Hestur"
+    ],
+    "name:dan_x_preferred":[
+        "Hestur"
+    ],
     "name:ell_x_preferred":[
         "\u03a7\u03ad\u03c3\u03c4\u03bf\u03c5\u03c1"
     ],
@@ -36,6 +42,9 @@
     ],
     "name:fao_x_preferred":[
         "Hestoy"
+    ],
+    "name:fas_x_preferred":[
+        "\u0647\u0633\u062a\u0648\u0631"
     ],
     "name:heb_x_preferred":[
         "\u05d4\u05e1\u05d8\u05d5\u05e8"
@@ -123,7 +132,7 @@
         }
     ],
     "wof:id":1125849473,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893395,
     "wof:name":"Hestur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/584/954/3/1125849543.geojson
+++ b/data/112/584/954/3/1125849543.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0648\u0644\u0649"
+    ],
+    "name:cat_x_preferred":[
+        "M\u00fali"
+    ],
     "name:dan_x_preferred":[
         "M\u00fali"
     ],
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":1125849543,
-    "wof:lastmodified":1566596212,
+    "wof:lastmodified":1690893394,
     "wof:name":"M\u00fali",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/586/160/5/1125861605.geojson
+++ b/data/112/586/160/5/1125861605.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sk\u00e1lav\u00edk"
+    ],
     "name:ces_x_preferred":[
         "Sk\u00e1lav\u00edk"
     ],
@@ -43,6 +46,9 @@
     "name:hun_x_preferred":[
         "Sk\u00e1lav\u00edk"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b9\u30b3\u30fc\u30e9\u30f4\u30a3\u30fc\u30af"
+    ],
     "name:lit_x_preferred":[
         "Skalavikas"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:und_x_variant":[
         "Sk\u00e5levig"
+    ],
+    "name:zho_x_preferred":[
+        "\u65af\u5361\u62c9\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":1125861605,
-    "wof:lastmodified":1566596205,
+    "wof:lastmodified":1690893382,
     "wof:name":"Sk\u00e1lav\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/587/211/5/1125872115.geojson
+++ b/data/112/587/211/5/1125872115.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0646\u064a\u0633"
+    ],
+    "name:cat_x_preferred":[
+        "Nes"
+    ],
     "name:dan_x_preferred":[
         "Nes"
     ],
@@ -33,6 +39,9 @@
     ],
     "name:fao_x_preferred":[
         "Nes"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06cc\u0633"
     ],
     "name:fin_x_preferred":[
         "Nes"
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":1125872115,
-    "wof:lastmodified":1566596207,
+    "wof:lastmodified":1690893385,
     "wof:name":"Nes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/588/114/7/1125881147.geojson
+++ b/data/112/588/114/7/1125881147.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "N\u00f3lsoy"
+    ],
     "name:dan_x_preferred":[
         "N\u00f3lsoy bygd"
     ],
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":1125881147,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893383,
     "wof:name":"N\u00f3lsoy",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/588/421/9/1125884219.geojson
+++ b/data/112/588/421/9/1125884219.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "G\u00f8tugj\u00f3gv"
+    ],
     "name:dan_x_preferred":[
         "G\u00f8tugj\u00f8gv"
     ],
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":1125884219,
-    "wof:lastmodified":1566596205,
+    "wof:lastmodified":1690893383,
     "wof:name":"G\u00f8tugj\u00f3gv",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/588/426/9/1125884269.geojson
+++ b/data/112/588/426/9/1125884269.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "S\u00f8ldarfj\u00f8r\u00f0ur"
+    ],
     "name:dan_x_preferred":[
         "S\u00f8ldarfj\u00f8r\u00f0ur"
     ],
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":1125884269,
-    "wof:lastmodified":1566596205,
+    "wof:lastmodified":1690893383,
     "wof:name":"S\u00f8ldarfj\u00f8r\u00ffur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/108/9/1125891089.geojson
+++ b/data/112/589/108/9/1125891089.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0644\u0686\u0648\u0633\u0627"
+    ],
+    "name:cat_x_preferred":[
+        "Lj\u00f3s\u00e1"
+    ],
     "name:dan_x_preferred":[
         "Lj\u00f3s\u00e1"
     ],
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":1125891089,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893384,
     "wof:name":"Lj\u00f3s\u00e1",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/589/110/5/1125891105.geojson
+++ b/data/112/589/110/5/1125891105.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Morskranes"
+    ],
     "name:dan_x_preferred":[
         "Morskranes"
     ],
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":1125891105,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893384,
     "wof:name":"Morskranes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/111/5/1125891115.geojson
+++ b/data/112/589/111/5/1125891115.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Nor\u00f0toftir"
+    ],
     "name:dan_x_preferred":[
         "Nor\u00f0toftir"
     ],
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":1125891115,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893383,
     "wof:name":"Nor\u00fftoftir",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/589/113/1/1125891131.geojson
+++ b/data/112/589/113/1/1125891131.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u064a\u0631\u0627\u0631\u0628\u0627\u0643\u0649"
+    ],
+    "name:cat_x_preferred":[
+        "Oyrarbakki"
+    ],
+    "name:ces_x_preferred":[
+        "Oyrarbakki"
+    ],
     "name:dan_x_preferred":[
         "Oyrarbakki"
     ],
@@ -115,7 +124,7 @@
         }
     ],
     "wof:id":1125891131,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893384,
     "wof:name":"Oyrarbakki",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/755/7/1125897557.geojson
+++ b/data/112/589/755/7/1125897557.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0633\u0643\u0627\u0631\u0641\u0627\u0646\u064a\u0633"
+    ],
+    "name:cat_x_preferred":[
+        "Skarvanes"
+    ],
     "name:dan_x_preferred":[
         "Skarvanes"
     ],
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":1125897557,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893383,
     "wof:name":"Skarvanes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/759/3/1125897593.geojson
+++ b/data/112/589/759/3/1125897593.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0633\u0643\u064a\u067e\u0627\u0646\u064a\u0633"
+    ],
+    "name:cat_x_preferred":[
+        "Skipanes"
+    ],
     "name:dan_x_preferred":[
         "Skipanes"
     ],
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":1125897593,
-    "wof:lastmodified":1566596206,
+    "wof:lastmodified":1690893384,
     "wof:name":"Skipanes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/626/1/1125906261.geojson
+++ b/data/112/590/626/1/1125906261.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Hvalv\u00edk"
+    ],
+    "name:cat_x_preferred":[
+        "Hvalv\u00edk"
+    ],
+    "name:ces_x_preferred":[
+        "Hvalv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Hvalv\u00edk"
     ],
@@ -125,7 +134,7 @@
         }
     ],
     "wof:id":1125906261,
-    "wof:lastmodified":1566596207,
+    "wof:lastmodified":1690893386,
     "wof:name":"Hvalv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/626/5/1125906265.geojson
+++ b/data/112/590/626/5/1125906265.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Lambarei\u00f0i"
+    ],
     "name:dan_x_preferred":[
         "Lambarei\u00f0i"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":1125906265,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893386,
     "wof:name":"Lambarei\u00ffi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/627/7/1125906277.geojson
+++ b/data/112/590/627/7/1125906277.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Stykki\u00f0"
+    ],
+    "name:cat_x_preferred":[
+        "Stykki\u00f0"
+    ],
     "name:dan_x_preferred":[
         "Stykki\u00f0"
     ],
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":1125906277,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893386,
     "wof:name":"Stykki\u00ff",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/642/5/1125906425.geojson
+++ b/data/112/590/642/5/1125906425.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sv\u00edn\u00e1ir"
+    ],
     "name:dan_x_preferred":[
         "Sv\u00edn\u00e1ir"
     ],
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":1125906425,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893386,
     "wof:name":"Sv\u00edn\u00e1ir",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/647/5/1125906475.geojson
+++ b/data/112/590/647/5/1125906475.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0641\u064a\u0643\u0627\u0631\u0628\u064a\u0631\u062c\u0649"
+    ],
+    "name:cat_x_preferred":[
+        "V\u00edkarbyrgi"
+    ],
     "name:dan_x_preferred":[
         "V\u00edkarbyrgi"
     ],
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":1125906475,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893387,
     "wof:name":"V\u00edkarbyrgi",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/690/1/1125906901.geojson
+++ b/data/112/590/690/1/1125906901.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Nor\u00f0radalur"
+    ],
+    "name:cat_x_preferred":[
+        "Nor\u00f0radalur"
+    ],
     "name:dan_x_preferred":[
         "Nor\u00f0radalur"
     ],
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":1125906901,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893387,
     "wof:name":"Nor\u00ffradalur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/691/5/1125906915.geojson
+++ b/data/112/590/691/5/1125906915.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Streymnes"
+    ],
+    "name:cat_x_preferred":[
+        "Streymnes"
+    ],
+    "name:ces_x_preferred":[
+        "Streymnes"
+    ],
     "name:dan_x_preferred":[
         "Streymnes"
     ],
@@ -63,6 +72,9 @@
     ],
     "name:und_x_variant":[
         "Str\u00f6mn\u00e6s"
+    ],
+    "name:zho_x_preferred":[
+        "\u65af\u7279\u96f7\u59c6\u5185\u65af"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -118,7 +130,7 @@
         }
     ],
     "wof:id":1125906915,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893387,
     "wof:name":"Streymnes",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/693/5/1125906935.geojson
+++ b/data/112/590/693/5/1125906935.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Sund"
+    ],
+    "name:cat_x_preferred":[
+        "Sund"
+    ],
     "name:dan_x_preferred":[
         "Sund"
     ],
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":1125906935,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893387,
     "wof:name":"Sund",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/694/7/1125906947.geojson
+++ b/data/112/590/694/7/1125906947.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Vatnsoyrar"
+    ],
     "name:dan_x_preferred":[
         "Vatnsoyrar"
     ],
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":1125906947,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893386,
     "wof:name":"Vatnsoyrar",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/590/699/9/1125906999.geojson
+++ b/data/112/590/699/9/1125906999.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sy\u00f0rug\u00f8ta"
+    ],
     "name:dan_x_preferred":[
         "Sy\u00f0rug\u00f8ta"
     ],
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":1125906999,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893387,
     "wof:name":"Sy\u00ffrug\u00f8ta",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/591/072/5/1125910725.geojson
+++ b/data/112/591/072/5/1125910725.geojson
@@ -22,10 +22,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bel_x_preferred":[
+        "\u0420\u0443\u043d\u0430\u0432\u0456\u043a"
+    ],
     "name:cat_x_preferred":[
         "Runav\u00edk"
     ],
     "name:ces_x_preferred":[
+        "Runav\u00edk"
+    ],
+    "name:cym_x_preferred":[
         "Runav\u00edk"
     ],
     "name:dan_x_preferred":[
@@ -97,11 +103,17 @@
     "name:swe_x_preferred":[
         "Runav\u00edk"
     ],
+    "name:tur_x_preferred":[
+        "Runav\u00edk"
+    ],
     "name:ukr_x_preferred":[
         "\u0420\u0443\u043d\u0430\u0432\u0456\u043a"
     ],
     "name:und_x_variant":[
         "Runevig"
+    ],
+    "name:zho_x_preferred":[
+        "\u9c81\u7eb3\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -156,7 +168,7 @@
         }
     ],
     "wof:id":1125910725,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893389,
     "wof:name":"Runav\u00edk",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/591/073/5/1125910735.geojson
+++ b/data/112/591/073/5/1125910735.geojson
@@ -25,6 +25,12 @@
     "name:bel_x_preferred":[
         "\u0412\u0451\u0441\u043a\u0430 \u0421\u0430\u043a\u0441\u0443\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Saksun"
+    ],
+    "name:ces_x_preferred":[
+        "Saksun"
+    ],
     "name:dan_x_preferred":[
         "Saksun"
     ],
@@ -37,6 +43,9 @@
     "name:fao_x_preferred":[
         "Saksun"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u06a9\u0633\u0648\u0646"
+    ],
     "name:fin_x_preferred":[
         "Saksun"
     ],
@@ -46,8 +55,17 @@
     "name:hun_x_preferred":[
         "Saksun"
     ],
+    "name:ido_x_preferred":[
+        "Saksun"
+    ],
     "name:isl_x_preferred":[
         "Saksun"
+    ],
+    "name:ita_x_preferred":[
+        "Saksun"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b5\u30af\u30bd\u30f3"
     ],
     "name:lit_x_preferred":[
         "Saksunas"
@@ -75,6 +93,9 @@
     ],
     "name:und_x_variant":[
         "Saksen"
+    ],
+    "name:zho_x_preferred":[
+        "\u8428\u514b\u68ee"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -130,7 +151,7 @@
         }
     ],
     "wof:id":1125910735,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893388,
     "wof:name":"Saksun",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/591/496/5/1125914965.geojson
+++ b/data/112/591/496/5/1125914965.geojson
@@ -25,6 +25,9 @@
     "name:cat_x_preferred":[
         "Haldarsv\u00edk"
     ],
+    "name:cat_x_variant":[
+        "Hald\u00f3rsv\u00edk"
+    ],
     "name:ces_x_preferred":[
         "Haldarsv\u00edk"
     ],
@@ -34,14 +37,23 @@
     "name:deu_x_preferred":[
         "Haldarsv\u00edk"
     ],
+    "name:deu_x_variant":[
+        "Hald\u00f3rsv\u00edk"
+    ],
     "name:eng_x_preferred":[
         "Haldarsv\u00edk"
+    ],
+    "name:eng_x_variant":[
+        "Hald\u00f3rsv\u00edk"
     ],
     "name:fao_x_preferred":[
         "Haldarsv\u00edk"
     ],
     "name:fra_x_preferred":[
         "Haldarsv\u00edk"
+    ],
+    "name:fra_x_variant":[
+        "Hald\u00f3rsv\u00edk"
     ],
     "name:glv_x_preferred":[
         "Haldarsv\u00edk"
@@ -58,6 +70,9 @@
     "name:nob_x_preferred":[
         "Haldarsv\u00edk"
     ],
+    "name:nob_x_variant":[
+        "Hald\u00f3rsv\u00edk"
+    ],
     "name:pol_x_preferred":[
         "Haldarsv\u00edk"
     ],
@@ -69,6 +84,9 @@
     ],
     "name:swe_x_preferred":[
         "Haldarsv\u00edk"
+    ],
+    "name:tur_x_preferred":[
+        "Hald\u00f3rsv\u00edk"
     ],
     "name:und_x_variant":[
         "Hald\u00f3rsv\u00edk"
@@ -127,7 +145,7 @@
         }
     ],
     "wof:id":1125914965,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893388,
     "wof:name":"Haldarsv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/591/497/9/1125914979.geojson
+++ b/data/112/591/497/9/1125914979.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0627\u0646\u0627\u0646 \u062c\u0644\u064a\u06a4\u0648\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "Innan Glyvur"
+    ],
     "name:dan_x_preferred":[
         "Innan Glyvur"
     ],
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":1125914979,
-    "wof:lastmodified":1566596208,
+    "wof:lastmodified":1690893388,
     "wof:name":"Innan Glyvur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/591/500/7/1125915007.geojson
+++ b/data/112/591/500/7/1125915007.geojson
@@ -40,6 +40,9 @@
     "name:fra_x_preferred":[
         "Kirkja"
     ],
+    "name:gle_x_preferred":[
+        "Kirkja"
+    ],
     "name:hun_x_preferred":[
         "Kirkja"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:und_x_variant":[
         "Kirke"
+    ],
+    "name:zho_x_preferred":[
+        "\u57fa\u5c14\u6070"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -126,7 +132,7 @@
         }
     ],
     "wof:id":1125915007,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893388,
     "wof:name":"Kirkja",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/591/508/3/1125915083.geojson
+++ b/data/112/591/508/3/1125915083.geojson
@@ -22,11 +22,17 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Kolbanargj\u00f3gv"
+    ],
     "name:dan_x_preferred":[
         "Kolbanargj\u00f3gv"
     ],
     "name:deu_x_preferred":[
         "Kolbanargj\u00f3gv"
+    ],
+    "name:deu_x_variant":[
+        "Kolbeinagj\u00f3gv"
     ],
     "name:eng_x_preferred":[
         "Kolbeinagjogv"
@@ -40,6 +46,9 @@
     ],
     "name:fra_x_preferred":[
         "Kolbanargj\u00f3gv"
+    ],
+    "name:fra_x_variant":[
+        "Kolbeinagj\u00f3gv"
     ],
     "name:hun_x_preferred":[
         "Kolbanargj\u00f3gv"
@@ -83,8 +92,8 @@
     "woe:name_adm1":"Sy\u00f0ra Eysturoy",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        102191581,
         85633153,
+        102191581,
         136253045
     ],
     "wof:breaches":[],
@@ -108,7 +117,7 @@
         }
     ],
     "wof:id":1125915083,
-    "wof:lastmodified":1636497649,
+    "wof:lastmodified":1690893388,
     "wof:name":"Kolbeinagjogv",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/592/903/3/1125929033.geojson
+++ b/data/112/592/903/3/1125929033.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0644\u062a\u0648\u0631"
+    ],
     "name:aze_x_preferred":[
         "Koltur adas\u0131"
+    ],
+    "name:bar_x_preferred":[
+        "Koltur"
     ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u041a\u0430\u043b\u044c\u0442\u0443\u0440"
@@ -52,8 +58,14 @@
     "name:est_x_preferred":[
         "Koltur"
     ],
+    "name:eus_x_preferred":[
+        "Koltur"
+    ],
     "name:fao_x_preferred":[
         "Koltur"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0644\u062a\u0648\u0631"
     ],
     "name:fin_x_preferred":[
         "Koltur"
@@ -93,6 +105,9 @@
     ],
     "name:kor_x_variant":[
         "\ucf5c\ud22c\ub974\uc12c"
+    ],
+    "name:lav_x_preferred":[
+        "Koltura"
     ],
     "name:lit_x_preferred":[
         "Kolturas"
@@ -134,6 +149,9 @@
         "\u041a\u043e\u043b\u0442\u0443\u0440"
     ],
     "name:swe_x_preferred":[
+        "Koltur"
+    ],
+    "name:tur_x_preferred":[
         "Koltur"
     ],
     "name:ukr_x_preferred":[
@@ -195,7 +213,7 @@
         }
     ],
     "wof:id":1125929033,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893380,
     "wof:name":"Koltur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/592/907/7/1125929077.geojson
+++ b/data/112/592/907/7/1125929077.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Oyri"
+    ],
+    "name:ces_x_preferred":[
+        "Oyri"
+    ],
     "name:dan_x_preferred":[
         "Oyri"
     ],
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":1125929077,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893379,
     "wof:name":"Oyri",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/593/126/7/1125931267.geojson
+++ b/data/112/593/126/7/1125931267.geojson
@@ -49,6 +49,9 @@
     "name:hun_x_preferred":[
         "Nor\u00f0rag\u00f8ta"
     ],
+    "name:ind_x_preferred":[
+        "Nor\u00f0rag\u00f8ta"
+    ],
     "name:isl_x_preferred":[
         "Nor\u00f0rag\u00f8ta"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:und_x_variant":[
         "Nordreg\u00f6te"
+    ],
+    "name:zho_x_preferred":[
+        "\u5317\u683c\u5854"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":1125931267,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893379,
     "wof:name":"Nor\u00ffrag\u00f8ta",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/594/933/5/1125949335.geojson
+++ b/data/112/594/933/5/1125949335.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Mykines"
+    ],
     "name:dan_x_preferred":[
         "Mykines"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03af\u03ba\u03b9\u03bd\u03b5\u03c2"
     ],
     "name:eng_x_preferred":[
         "Mykines"
@@ -41,6 +47,12 @@
         "Mi\u010dinesas"
     ],
     "name:nld_x_preferred":[
+        "Mykines"
+    ],
+    "name:nno_x_preferred":[
+        "Mykines"
+    ],
+    "name:nob_x_preferred":[
         "Mykines"
     ],
     "name:oss_x_preferred":[
@@ -63,6 +75,9 @@
     ],
     "name:urd_x_variant":[
         "\u0645\u06cc\u06a9\u0627\u0626\u0646\u0632"
+    ],
+    "name:zho_x_preferred":[
+        "\u7c73\u57fa\u5185\u65af"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -104,7 +119,7 @@
         }
     ],
     "wof:id":1125949335,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893379,
     "wof:name":"Mykines",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/595/404/7/1125954047.geojson
+++ b/data/112/595/404/7/1125954047.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Hv\u00edtanes"
+    ],
+    "name:cat_x_preferred":[
+        "Hv\u00edtanes"
+    ],
     "name:dan_x_preferred":[
         "Hv\u00edtanes"
     ],
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":1125954047,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893380,
     "wof:name":"Hv\u00edtanes",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/595/515/7/1125955157.geojson
+++ b/data/112/595/515/7/1125955157.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Trongisv\u00e1gur"
+    ],
     "name:dan_x_preferred":[
         "Trongisv\u00e1gur"
     ],
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1125955157,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893380,
     "wof:name":"Trongisv\u00e1gur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/598/185/1/1125981851.geojson
+++ b/data/112/598/185/1/1125981851.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0633\u06a4\u064a\u0646\u0648\u0649"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0421\u0432\u0443\u0439\u043d\u0430\u0439"
+    ],
+    "name:cat_x_preferred":[
+        "Sv\u00ednoy"
     ],
     "name:dan_x_preferred":[
         "Sv\u00ednoy bygd"
@@ -50,6 +56,12 @@
         "Svuinojus"
     ],
     "name:nld_x_preferred":[
+        "Sv\u00ednoy"
+    ],
+    "name:nno_x_preferred":[
+        "Sv\u00ednoy"
+    ],
+    "name:nob_x_preferred":[
         "Sv\u00ednoy"
     ],
     "name:oss_x_preferred":[
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":1125981851,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893390,
     "wof:name":"Sv\u00ednoy",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/598/215/5/1125982155.geojson
+++ b/data/112/598/215/5/1125982155.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Leynar"
+    ],
+    "name:cat_x_preferred":[
+        "Leynar"
+    ],
     "name:dan_x_preferred":[
         "Leynar"
     ],
@@ -36,6 +42,9 @@
     ],
     "name:fao_x_preferred":[
         "Leynar"
+    ],
+    "name:fas_x_preferred":[
+        "\u0644\u06cc\u0646\u0627\u0631"
     ],
     "name:fra_x_preferred":[
         "Leynar"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":1125982155,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893390,
     "wof:name":"Leynar",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/598/217/1/1125982171.geojson
+++ b/data/112/598/217/1/1125982171.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Nes"
+    ],
     "name:dan_x_preferred":[
         "Nes"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:fao_x_preferred":[
         "Nes"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06cc\u0633"
     ],
     "name:fra_x_preferred":[
         "Nes"
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":1125982171,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893389,
     "wof:name":"Nes",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/598/218/5/1125982185.geojson
+++ b/data/112/598/218/5/1125982185.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Lopra"
+    ],
     "name:dan_x_preferred":[
         "Lopra"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":1125982185,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893389,
     "wof:name":"Lopra",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/598/219/9/1125982199.geojson
+++ b/data/112/598/219/9/1125982199.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0643\u0644\u0627\u062f\u0627\u0644\u0648\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "Mikladalur"
+    ],
     "name:dan_x_preferred":[
         "Mikladalur"
     ],
@@ -37,10 +43,16 @@
     "name:fra_x_preferred":[
         "Mikladalur"
     ],
+    "name:gle_x_preferred":[
+        "Mikladalur"
+    ],
     "name:heb_x_preferred":[
         "\u05de\u05d9\u05e7\u05dc\u05d0\u05d3\u05d0\u05dc\u05d5\u05e8"
     ],
     "name:hun_x_preferred":[
+        "Mikladalur"
+    ],
+    "name:ita_x_preferred":[
         "Mikladalur"
     ],
     "name:lit_x_preferred":[
@@ -72,6 +84,9 @@
     ],
     "name:und_x_variant":[
         "Mygledal"
+    ],
+    "name:zho_x_preferred":[
+        "\u7c73\u514b\u62c9\u8fbe\u52d2"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -127,7 +142,7 @@
         }
     ],
     "wof:id":1125982199,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893389,
     "wof:name":"Mikladalur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/598/220/5/1125982205.geojson
+++ b/data/112/598/220/5/1125982205.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Selatra\u00f0"
+    ],
     "name:dan_x_preferred":[
         "Selatra\u00f0"
     ],
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":1125982205,
-    "wof:lastmodified":1566596209,
+    "wof:lastmodified":1690893389,
     "wof:name":"Selatra\u00ff",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/598/224/1/1125982241.geojson
+++ b/data/112/598/224/1/1125982241.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sk\u00e1la"
+    ],
     "name:dan_x_preferred":[
         "Sk\u00e1la"
     ],
@@ -43,6 +46,9 @@
     "name:isl_x_preferred":[
         "Sk\u00e1la"
     ],
+    "name:ita_x_preferred":[
+        "Sk\u00e1la"
+    ],
     "name:jpn_x_preferred":[
         "\u30b9\u30ab\u30fc\u30ea"
     ],
@@ -55,11 +61,17 @@
     "name:nob_x_preferred":[
         "Sk\u00e1li"
     ],
+    "name:nob_x_variant":[
+        "Sk\u00e1la"
+    ],
     "name:pol_x_preferred":[
         "Sk\u00e1li"
     ],
     "name:ron_x_preferred":[
         "Sk\u00e1li"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u043a\u043e\u0430\u043b\u0430"
     ],
     "name:spa_x_preferred":[
         "Sk\u00e1li"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":1125982241,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893390,
     "wof:name":"Sk\u00e1li",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/598/224/5/1125982245.geojson
+++ b/data/112/598/224/5/1125982245.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sk\u00favoy"
+    ],
     "name:dan_x_preferred":[
         "Sk\u00favoy"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:und_x_variant":[
         "Sk\u00favoyarbygd"
+    ],
+    "name:zho_x_preferred":[
+        "\u65af\u5e93\u6c83\u4f0a"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":1125982245,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893390,
     "wof:name":"Sk\u00favoy",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/598/225/5/1125982255.geojson
+++ b/data/112/598/225/5/1125982255.geojson
@@ -25,6 +25,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c1\u09ae\u09cd\u09ac\u09be"
     ],
+    "name:cat_x_preferred":[
+        "Sumba"
+    ],
     "name:ceb_x_preferred":[
         "Sumba"
     ],
@@ -76,10 +79,16 @@
     "name:ron_x_preferred":[
         "Sumba"
     ],
+    "name:rus_x_preferred":[
+        "\u0421\u0443\u043c\u0431\u0430"
+    ],
     "name:spa_x_preferred":[
         "Sumba"
     ],
     "name:swe_x_preferred":[
+        "Sumba"
+    ],
+    "name:tur_x_preferred":[
         "Sumba"
     ],
     "name:und_x_variant":[
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":1125982255,
-    "wof:lastmodified":1636495064,
+    "wof:lastmodified":1690893390,
     "wof:name":"Sumba",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/598/311/9/1125983119.geojson
+++ b/data/112/598/311/9/1125983119.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Kaldbak"
+    ],
+    "name:cat_x_preferred":[
+        "Kaldbak"
+    ],
     "name:dan_x_preferred":[
         "Kaldbak"
     ],
@@ -60,6 +66,9 @@
     ],
     "name:ron_x_preferred":[
         "Kaldbak"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043b\u044c\u0434\u0431\u0430\u043a"
     ],
     "name:spa_x_preferred":[
         "Kaldbak"
@@ -121,7 +130,7 @@
         }
     ],
     "wof:id":1125983119,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893390,
     "wof:name":"Kaldbak",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/600/661/5/1126006615.geojson
+++ b/data/112/600/661/5/1126006615.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0627\u0646\u064a\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "\u00c1nirnar"
+    ],
     "name:dan_x_preferred":[
         "\u00c1nir"
     ],
@@ -127,7 +133,7 @@
         }
     ],
     "wof:id":1126006615,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893392,
     "wof:name":"\u00c1nir",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/600/662/1/1126006621.geojson
+++ b/data/112/600/662/1/1126006621.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "\u00c1rnafj\u00f8r\u00f0ur"
+    ],
     "name:dan_x_preferred":[
         "\u00c1rnafj\u00f8r\u00f0ur"
     ],
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":1126006621,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893393,
     "wof:name":"\u00c1rnafj\u00f8r\u00ffur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/663/3/1126006633.geojson
+++ b/data/112/600/663/3/1126006633.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Elduv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Elduv\u00edk"
     ],
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":1126006633,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893392,
     "wof:name":"Elduv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/665/5/1126006655.geojson
+++ b/data/112/600/665/5/1126006655.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Saltnes"
+    ],
     "name:dan_x_preferred":[
         "Saltnes"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "Saltn\u00e6s"
+    ],
+    "name:zho_x_preferred":[
+        "\u8428\u5c14\u7279\u5185\u65af"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":1126006655,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893393,
     "wof:name":"Saltnes",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/666/3/1126006663.geojson
+++ b/data/112/600/666/3/1126006663.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Signab\u00f8ur"
+    ],
+    "name:cat_x_preferred":[
+        "Signab\u00f8ur"
+    ],
     "name:dan_x_preferred":[
         "Signab\u00f8ur"
     ],
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":1126006663,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893392,
     "wof:name":"Signab\u00f8ur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/860/1/1126008601.geojson
+++ b/data/112/600/860/1/1126008601.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Akrar"
+    ],
     "name:dan_x_preferred":[
         "Akrar"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:fra_x_preferred":[
         "Akrar"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e7\u05e8\u05d0\u05e8"
     ],
     "name:hun_x_preferred":[
         "Akrar"
@@ -75,6 +81,9 @@
     ],
     "name:und_x_variant":[
         "\u00d6grum"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u514b\u62c9\u5c14"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -130,7 +139,7 @@
         }
     ],
     "wof:id":1126008601,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893392,
     "wof:name":"Akrar",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/861/9/1126008619.geojson
+++ b/data/112/600/861/9/1126008619.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Argir"
+    ],
+    "name:cat_x_preferred":[
+        "Argir"
+    ],
     "name:ces_x_preferred":[
         "Argir"
     ],
@@ -41,6 +47,9 @@
         "Argir"
     ],
     "name:fra_x_preferred":[
+        "Argir"
+    ],
+    "name:frr_x_preferred":[
         "Argir"
     ],
     "name:glv_x_preferred":[
@@ -154,7 +163,7 @@
         }
     ],
     "wof:id":1126008619,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893391,
     "wof:name":"Argir",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/865/3/1126008653.geojson
+++ b/data/112/600/865/3/1126008653.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0642\u0627\u0648\u0633\u0627 \u062f\u0648\u0644\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0648\u0633\u0627 \u062f\u0648\u0644\u0627\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "G\u00e1sadalur"
+    ],
     "name:dan_x_preferred":[
         "G\u00e1sadalur"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:fra_x_preferred":[
         "G\u00e1sadalur"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05d0\u05e1\u05d3\u05dc\u05d5\u05e8"
     ],
     "name:hun_x_preferred":[
         "G\u00e1sadalur"
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":1126008653,
-    "wof:lastmodified":1566596211,
+    "wof:lastmodified":1690893392,
     "wof:name":"G\u00e1sadalur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/600/874/9/1126008749.geojson
+++ b/data/112/600/874/9/1126008749.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Sandv\u00edk"
+    ],
+    "name:ces_x_preferred":[
+        "Sandv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Sandv\u00edk"
     ],
@@ -69,6 +75,9 @@
     ],
     "name:und_x_variant":[
         "Sandvig"
+    ],
+    "name:zho_x_preferred":[
+        "\u6851\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -124,7 +133,7 @@
         }
     ],
     "wof:id":1126008749,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893391,
     "wof:name":"Sandv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/600/875/5/1126008755.geojson
+++ b/data/112/600/875/5/1126008755.geojson
@@ -22,6 +22,18 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "Nesv\u00edk"
+    ],
+    "name:bul_x_preferred":[
+        "\u041d\u0435\u0441\u0432\u0443\u0439\u043a"
+    ],
+    "name:cat_x_preferred":[
+        "Nesv\u00edk"
+    ],
+    "name:ces_x_preferred":[
+        "Nesv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Nesv\u00edk"
     ],
@@ -118,7 +130,7 @@
         }
     ],
     "wof:id":1126008755,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893391,
     "wof:name":"Nesv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/601/794/3/1126017943.geojson
+++ b/data/112/601/794/3/1126017943.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0647\u0627\u0631\u0627\u0644\u062f\u0633\u0648\u0646\u062f"
+    ],
+    "name:cat_x_preferred":[
+        "Haraldssund"
+    ],
     "name:dan_x_preferred":[
         "Haraldssund"
     ],
@@ -121,7 +127,7 @@
         }
     ],
     "wof:id":1126017943,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893391,
     "wof:name":"Haraldssund",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/601/795/5/1126017955.geojson
+++ b/data/112/601/795/5/1126017955.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:bar_x_preferred":[
+        "H\u00f3sv\u00edk"
+    ],
+    "name:cat_x_preferred":[
+        "H\u00f3sv\u00edk"
+    ],
+    "name:ces_x_preferred":[
+        "H\u00f3sv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "H\u00f3sv\u00edk"
     ],
@@ -66,6 +75,9 @@
     ],
     "name:und_x_variant":[
         "Torsvig"
+    ],
+    "name:zho_x_preferred":[
+        "\u970d\u65af\u7ef4\u514b"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -121,7 +133,7 @@
         }
     ],
     "wof:id":1126017955,
-    "wof:lastmodified":1566596210,
+    "wof:lastmodified":1690893391,
     "wof:name":"H\u00f3sv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/602/118/7/1126021187.geojson
+++ b/data/112/602/118/7/1126021187.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Glyvrar"
+    ],
     "name:dan_x_preferred":[
         "Glyvrar"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":1126021187,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893380,
     "wof:name":"Glyvrar",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/602/119/3/1126021193.geojson
+++ b/data/112/602/119/3/1126021193.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Undir G\u00f8tuei\u00f0i"
+    ],
     "name:dan_x_preferred":[
         "G\u00f8tuei\u00f0i"
     ],
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":1126021193,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893381,
     "wof:name":"G\u00f8tuei\u00ffi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/602/468/3/1126024683.geojson
+++ b/data/112/602/468/3/1126024683.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "B\u00f8ur"
+    ],
     "name:dan_x_preferred":[
         "B\u00f8ur"
     ],
@@ -35,6 +38,9 @@
         "B\u00f8ur"
     ],
     "name:fao_x_preferred":[
+        "B\u00f8ur"
+    ],
+    "name:fin_x_preferred":[
         "B\u00f8ur"
     ],
     "name:fra_x_preferred":[
@@ -72,6 +78,9 @@
     ],
     "name:und_x_variant":[
         "B\u00f6"
+    ],
+    "name:zho_x_preferred":[
+        "\u4f2f\u4e4c\u5c14"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -126,7 +135,7 @@
         }
     ],
     "wof:id":1126024683,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893381,
     "wof:name":"B\u00f8ur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/602/562/7/1126025627.geojson
+++ b/data/112/602/562/7/1126025627.geojson
@@ -88,8 +88,14 @@
     "name:swe_x_preferred":[
         "Sandav\u00e1gur"
     ],
+    "name:tur_x_preferred":[
+        "Sandav\u00e1gur"
+    ],
     "name:und_x_variant":[
         "Sandev\u00e5g"
+    ],
+    "name:zho_x_preferred":[
+        "\u6851\u8fbe\u74e6\u53e4\u5c14"
     ],
     "qs_pg:aaroncc":"FO",
     "qs_pg:gn_country":"FO",
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":1126025627,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893381,
     "wof:name":"Sandav\u00e1gur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/602/582/1/1126025821.geojson
+++ b/data/112/602/582/1/1126025821.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Rituv\u00edk"
+    ],
     "name:dan_x_preferred":[
         "Rituv\u00edk"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":1126025821,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893382,
     "wof:name":"Rituv\u00edk",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/602/597/7/1126025977.geojson
+++ b/data/112/602/597/7/1126025977.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Oyndarfj\u00f8r\u00f0ur"
+    ],
     "name:dan_x_preferred":[
         "Oyndarfj\u00f8r\u00f0ur"
     ],
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":1126025977,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893381,
     "wof:name":"Oyndarfj\u00f8r\u00f0ur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/602/621/7/1126026217.geojson
+++ b/data/112/602/621/7/1126026217.geojson
@@ -25,6 +25,9 @@
     "name:cat_x_preferred":[
         "Nor\u00f0sk\u00e1li"
     ],
+    "name:ces_x_preferred":[
+        "Nor\u00f0sk\u00e1li"
+    ],
     "name:dan_x_preferred":[
         "Nor\u00f0sk\u00e1li"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":1126026217,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893380,
     "wof:name":"Nor\u00f0sk\u00e1li",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/602/674/9/1126026749.geojson
+++ b/data/112/602/674/9/1126026749.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u062f\u06a4\u0627\u062c\u0648\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "Mi\u00f0v\u00e1gur"
+    ],
+    "name:ces_x_preferred":[
+        "Mi\u00f0v\u00e1gur"
+    ],
     "name:dan_x_preferred":[
         "Mi\u00f0v\u00e1gur"
     ],
@@ -41,6 +50,9 @@
         "Mi\u00f0v\u00e1gur"
     ],
     "name:fra_x_preferred":[
+        "Mi\u00f0v\u00e1gur"
+    ],
+    "name:frr_x_preferred":[
         "Mi\u00f0v\u00e1gur"
     ],
     "name:glg_x_preferred":[
@@ -79,10 +91,16 @@
     "name:ron_x_preferred":[
         "Mi\u00f0v\u00e1gur"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0438\u0432\u043e\u0430\u0432\u0443\u0440"
+    ],
     "name:spa_x_preferred":[
         "Mi\u00f0v\u00e1gur"
     ],
     "name:swe_x_preferred":[
+        "Mi\u00f0v\u00e1gur"
+    ],
+    "name:tur_x_preferred":[
         "Mi\u00f0v\u00e1gur"
     ],
     "name:und_x_variant":[
@@ -128,7 +146,7 @@
         }
     ],
     "wof:id":1126026749,
-    "wof:lastmodified":1566596203,
+    "wof:lastmodified":1690893380,
     "wof:name":"Mi\u00f0v\u00e1gur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/602/676/3/1126026763.geojson
+++ b/data/112/602/676/3/1126026763.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Fro\u00f0ba"
+    ],
     "name:dan_x_preferred":[
         "Fro\u00f0ba"
     ],
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":1126026763,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893381,
     "wof:name":"Fro\u00f0ba",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/603/480/5/1126034805.geojson
+++ b/data/112/603/480/5/1126034805.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0647\u064a\u0644\u0648\u0631\u0646\u0627\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "Hellurnar"
+    ],
     "name:dan_x_preferred":[
         "Hellur"
     ],
@@ -34,6 +40,9 @@
     "name:fao_x_preferred":[
         "Hellurnar"
     ],
+    "name:fra_x_preferred":[
+        "Hellurnar"
+    ],
     "name:hun_x_preferred":[
         "Hellur"
     ],
@@ -42,6 +51,9 @@
     ],
     "name:nob_x_preferred":[
         "Hellur"
+    ],
+    "name:nob_x_variant":[
+        "Hellurnar"
     ],
     "name:ron_x_preferred":[
         "Hellur"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":1126034805,
-    "wof:lastmodified":1566596205,
+    "wof:lastmodified":1690893382,
     "wof:name":"Hellur",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/112/605/697/9/1126056979.geojson
+++ b/data/112/605/697/9/1126056979.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Nor\u00f0depil"
+    ],
     "name:dan_x_preferred":[
         "Nor\u00f0depil"
     ],
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":1126056979,
-    "wof:lastmodified":1566596204,
+    "wof:lastmodified":1690893382,
     "wof:name":"Nor\u00ffdepil",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",

--- a/data/114/190/862/7/1141908627.geojson
+++ b/data/114/190/862/7/1141908627.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-6.82003361147,62.0300238232,-6.82003361147,62.0300238232",
+    "geom:bbox":"-6.820034,62.030024,-6.820034,62.030024",
     "geom:latitude":62.030024,
     "geom:longitude":-6.820034,
     "iso:country":"FO",
@@ -30,11 +30,23 @@
     "name:ara_x_variant":[
         "\u062a\u0648\u0634\u0647\u0627\u0641\u0646"
     ],
+    "name:arg_x_preferred":[
+        "T\u00f3rshavn"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0634\u0647\u0627\u0641\u0646"
+    ],
     "name:ast_x_preferred":[
         "Tors\u1e25avn"
     ],
+    "name:ast_x_variant":[
+        "T\u00f3rs\u1e25avn"
+    ],
     "name:aze_x_preferred":[
         "Torshavn"
+    ],
+    "name:bar_x_preferred":[
+        "T\u00f3rshavn"
     ],
     "name:bel_x_preferred":[
         "\u0422\u043e\u0440\u0441\u0445\u0430\u045e\u043d"
@@ -70,6 +82,9 @@
         "Thorshavn"
     ],
     "name:deu_x_preferred":[
+        "T\u00f3rshavn"
+    ],
+    "name:diq_x_preferred":[
         "T\u00f3rshavn"
     ],
     "name:ell_x_preferred":[
@@ -177,6 +192,9 @@
     "name:lmo_x_preferred":[
         "T\u00f3rshavn"
     ],
+    "name:mdf_x_preferred":[
+        "\u0422\u043e\u0440\u0441\u0433\u0430\u0432\u043d"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u043e\u0440\u0441\u0445\u0430\u0432\u043d"
     ],
@@ -188,6 +206,9 @@
     ],
     "name:mri_x_preferred":[
         "T\u00f3rshavn"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062a\u0648\u0634\u0647\u0627\u0648\u0646"
     ],
     "name:nan_x_preferred":[
         "T\u00f3rshavn"
@@ -228,6 +249,9 @@
     "name:ron_x_preferred":[
         "T\u00f3rshavn"
     ],
+    "name:rue_x_preferred":[
+        "\u0422\u043e\u0440\u0441\u0433\u0430\u0432\u043d"
+    ],
     "name:rus_x_preferred":[
         "\u0422\u043e\u0440\u0441\u0445\u0430\u0432\u043d"
     ],
@@ -246,6 +270,9 @@
     "name:spa_x_preferred":[
         "T\u00f3rshavn"
     ],
+    "name:sqi_x_preferred":[
+        "T\u00f3rshavn"
+    ],
     "name:srd_x_preferred":[
         "T\u00f3rshavn"
     ],
@@ -258,6 +285,9 @@
     "name:swe_x_preferred":[
         "Torshamn"
     ],
+    "name:swe_x_variant":[
+        "T\u00f3rshavn"
+    ],
     "name:szl_x_preferred":[
         "T\u00f3rshavn"
     ],
@@ -269,6 +299,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e17\u0e2d\u0e23\u0e4c\u0e2a\u0e40\u0e2e\u0e32\u0e19\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e17\u0e2d\u0e23\u0e4c\u0e40\u0e0a\u0e32\u0e19\u0e4c"
     ],
     "name:tur_x_preferred":[
         "T\u00f3rshavn"
@@ -287,6 +320,9 @@
     ],
     "name:war_x_preferred":[
         "T\u00f3rshavn"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6258\u5c14\u65af\u6e2f"
     ],
     "name:yor_x_preferred":[
         "T\u00f3rshavn"
@@ -405,7 +441,7 @@
     },
     "wof:country":"FO",
     "wof:created":1499130944,
-    "wof:geomhash":"702fdbad4e5f93a31c8207e3ae2679ac",
+    "wof:geomhash":"3c0454a58b0834c1ccd85f64e45328bf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -417,7 +453,7 @@
         }
     ],
     "wof:id":1141908627,
-    "wof:lastmodified":1566596214,
+    "wof:lastmodified":1690893396,
     "wof:name":"Torshavn",
     "wof:parent_id":85671213,
     "wof:placetype":"locality",
@@ -427,10 +463,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -6.82003361146798,
-    62.03002382318124,
-    -6.82003361146798,
-    62.03002382318124
+    -6.820034,
+    62.030024,
+    -6.820034,
+    62.030024
 ],
-  "geometry": {"coordinates":[-6.82003361146798,62.03002382318124],"type":"Point"}
+  "geometry": {"coordinates":[-6.820034,62.030024],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.